### PR TITLE
ci: activate hassfest to validate integration

### DIFF
--- a/.github/workflows/hassfest.yaml
+++ b/.github/workflows/hassfest.yaml
@@ -1,0 +1,14 @@
+name: Validate with hassfest
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron:  '0 0 * * *'
+
+jobs:
+  validate:
+    runs-on: "ubuntu-latest"
+    steps:
+        - uses: "actions/checkout@v3"
+        - uses: "home-assistant/actions/hassfest@master"

--- a/custom_components/osbee/manifest.json
+++ b/custom_components/osbee/manifest.json
@@ -10,5 +10,6 @@
   "issue_tracker": "https://github.com/chickenandpork/hass-osbee/issues",
   "requirements": [],
   "ssdp": [],
+  "version": "0.0.1",
   "zeroconf": []
 }


### PR DESCRIPTION
Per https://hacs.xyz/docs/publish/include#before-submitting , hassfest GitHub action is added to fast-fail any preventable issues.