### PR TITLE
Feature: Configurable default runtime

### DIFF
--- a/custom_components/osbee/__init__.py
+++ b/custom_components/osbee/__init__.py
@@ -25,4 +25,4 @@ _LOGGER = logging.getLogger(__name__)
 async def async_setup_entry(hass, entry, async_add_entities):
     """Config entry example."""
     # assuming API object stored here by __init__.py
-    _LOGGER.exception("__init__::async_setup_entry: entry is %s", entry)
+    _LOGGER.debug("__init__::async_setup_entry: entry is %s", entry)

--- a/custom_components/osbee/binary_sensor.py
+++ b/custom_components/osbee/binary_sensor.py
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Your controller/hub specific code."""
 
-    _LOGGER.warning("In binary_sensor.py::setup")
+    _LOGGER.debug("In binary_sensor.py::setup")
 
     return True
 
@@ -91,7 +91,7 @@ async def async_setup_platform(
     reconciled.
     """
 
-    _LOGGER.warning("In binary_sensor.py::async_setup_platform: config is %s", config)
+    _LOGGER.debug("In binary_sensor.py::async_setup_platform: config is %s", config)
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {"coordinators": {}, "hubs": {}}
     if config[CONF_HOST] not in hass.data[DOMAIN]["hubs"]:
@@ -114,7 +114,7 @@ async def async_setup_platform(
 
     # await coordinator.async_config_entry_first_refresh()
 
-    _LOGGER.warning(
+    _LOGGER.debug(
         "In binary_sensor.py::async_setup_platform: post-async_config_entry_first_refresh: data is %s",
         coordinator.data,
     )
@@ -143,7 +143,7 @@ class OSBeeZoneSensor(CoordinatorEntity, BinarySensorEntity):
 
     def __init__(self, coordinator, zone_id, zone_name):
         """Pass coordinator to CoordinatorEntity."""
-        _LOGGER.warning(
+        _LOGGER.debug(
             "In __init__::OSBeeZoneSensor::__init__: zone_id = %s",
             zone_id,
         )
@@ -157,7 +157,7 @@ class OSBeeZoneSensor(CoordinatorEntity, BinarySensorEntity):
         """Handle updated data from the coordinator."""
         mask = 1 << self._zone_id
         self._attr_is_on = (self.coordinator.data["zbits"] & mask) > 0
-        _LOGGER.warning(
+        _LOGGER.debug(
             "In __init__::OSBeeZoneSensor::_handle_coordinator_update, zone_id = %d, mask = %d, data[zbits] = %s, value=%s",
             self._zone_id,
             mask,
@@ -169,5 +169,5 @@ class OSBeeZoneSensor(CoordinatorEntity, BinarySensorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
-        _LOGGER.warning("In __init__::OSBeeZoneSensor::unique_id")
+        _LOGGER.debug("In __init__::OSBeeZoneSensor::unique_id")
         return f"""{self._mac.replace(":", "")}_zone_{self._zone_id}"""

--- a/custom_components/osbee/binary_sensor.py
+++ b/custom_components/osbee/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
     PLATFORM_SCHEMA,
     BinarySensorEntity,
 )
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -39,6 +39,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=1800): cv.positive_int,
         # vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
@@ -48,7 +49,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 #
 # hass.data[DOMAIN]: {
 #     "192.168.1.77": {
-#         "h": an OSBeeAPI ("192.168.1.77", <async_client session>)
+#         "h": an OSBeeAPI ("192.168.1.77", 900, <async_client session>)
 #         "c": an OSBeeHubCoordinator (hass, ^^ that OSBeeAPI)
 #     }, ...
 # }
@@ -95,7 +96,11 @@ async def async_setup_platform(
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {"coordinators": {}, "hubs": {}}
     if config[CONF_HOST] not in hass.data[DOMAIN]["hubs"]:
-        h = OSBeeAPI(config[CONF_HOST], async_create_clientsession(hass))
+        h = OSBeeAPI(
+            config[CONF_HOST],
+            config[CONF_TIMEOUT] if CONF_TIMEOUT in config else 900,
+            async_create_clientsession(hass),
+        )
         c = OSBeeHubCoordinator(hass, h)
 
         hass.data[DOMAIN]["hubs"].update({config[CONF_HOST]: {"h": h, "c": c}})

--- a/custom_components/osbee/coordinator.py
+++ b/custom_components/osbee/coordinator.py
@@ -24,7 +24,7 @@ class OSBeeHubCoordinator(DataUpdateCoordinator):
             update_interval=timedelta(seconds=3),
         )
         self.my_api = my_api
-        _LOGGER.warning("In coordinator.py::OSBeeHubCoordinator::__init__")
+        _LOGGER.debug("In coordinator.py::OSBeeHubCoordinator::__init__")
 
     async def _async_update_data(self):
         """Fetch data from API endpoint.
@@ -39,7 +39,7 @@ class OSBeeHubCoordinator(DataUpdateCoordinator):
                 # Grab active context variables to limit data required to be fetched from API
                 # Note: using context is not required if there is no need or ability to limit
                 # data retrieved from API.
-                _LOGGER.warning(
+                _LOGGER.debug(
                     "In coordinator.py::OSBeeHubCoordinator::_async_update_data"
                 )
                 listening_idx = set(self.async_contexts())

--- a/custom_components/osbee/osbeeapi.py
+++ b/custom_components/osbee/osbeeapi.py
@@ -16,12 +16,20 @@ _LOGGER = logging.getLogger(__name__)
 class OSBeeAPI:
     """aiohttp facade for API requests to OSB Hub device."""
 
-    def __init__(self, host, session: aiohttp.ClientSession) -> None:
+    def __init__(self, host, max_runtime: int, session: aiohttp.ClientSession) -> None:
         """Create an OSBeeAPI by offering a host, and an async session to get there."""
         self._host = host
         self._jc_cache = None
+        _LOGGER.warning("type of timeout/max_runtime is %s", type(max_runtime))
+        self._max_runtime = max_runtime
         self._session = session
         self.lock = Lock()
+        _LOGGER.warning(
+            "created OSBeeAPI at %s max_runtime %s (%s)",
+            self._host,
+            self._max_runtime,
+            type(self._max_runtime),
+        )
 
     async def fetch_data(self, index):
         """Get raw device state from the OSBee Hub via API.  No authentication yet considered."""
@@ -104,7 +112,7 @@ class OSBeeAPI:
             url = f"http://{self._host}/cc?dkey=opendoor&reset=1"
         else:
             new_bitz = self._jc_cache["zbits"]  # avoid triple-quoting
-            url = f"http://{self._host}/rp?dkey=opendoor&pid=77&zbits={new_bitz}&dur={30*60}"
+            url = f"http://{self._host}/rp?dkey=opendoor&pid=77&zbits={new_bitz}&dur={self._max_runtime}"
 
         async with self._session.get(url) as rp_request:
             if rp_request.status == 401:

--- a/custom_components/osbee/sensor.py
+++ b/custom_components/osbee/sensor.py
@@ -12,6 +12,7 @@ from homeassistant.components.sensor import (
 )
 from homeassistant.const import (
     CONF_HOST,
+    CONF_TIMEOUT,
     SIGNAL_STRENGTH_DECIBELS,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -41,6 +42,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=1800): cv.positive_int,
         # vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
@@ -50,7 +52,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 #
 # hass.data[DOMAIN]: {
 #     "192.168.1.77": {
-#         "h": an OSBeeAPI ("192.168.1.77", <async_client session>)
+#         "h": an OSBeeAPI ("192.168.1.77", 900, <async_client session>)
 #         "c": an OSBeeHubCoordinator (hass, ^^ that OSBeeAPI)
 #     }, ...
 # }
@@ -92,7 +94,11 @@ async def async_setup_platform(
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {"coordinators": {}, "hubs": {}}
     if config[CONF_HOST] not in hass.data[DOMAIN]["hubs"]:
-        h = OSBeeAPI(config[CONF_HOST], async_create_clientsession(hass))
+        h = OSBeeAPI(
+            config[CONF_HOST],
+            config[CONF_TIMEOUT] if CONF_TIMEOUT in config else 900,
+            async_create_clientsession(hass),
+        )
         c = OSBeeHubCoordinator(hass, h)
 
         hass.data[DOMAIN]["hubs"].update({config[CONF_HOST]: {"h": h, "c": c}})

--- a/custom_components/osbee/sensor.py
+++ b/custom_components/osbee/sensor.py
@@ -33,7 +33,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Your controller/hub specific code."""
 
-    _LOGGER.warning("In sensor.py::setup")
+    _LOGGER.debug("In sensor.py::setup")
 
     return True
 
@@ -88,7 +88,7 @@ async def async_setup_platform(
 ) -> None:
     """Set up the OSBee sensor platform."""
 
-    _LOGGER.warning("In sensor.py::async_setup_platform: config is %s", config)
+    _LOGGER.debug("In sensor.py::async_setup_platform: config is %s", config)
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {"coordinators": {}, "hubs": {}}
     if config[CONF_HOST] not in hass.data[DOMAIN]["hubs"]:
@@ -111,14 +111,14 @@ async def async_setup_platform(
 
     # await coordinator.async_config_entry_first_refresh()
 
-    _LOGGER.warning(
+    _LOGGER.debug(
         "In sensor.py::async_setup_platform: post-async_config_entry_first_refresh: data is %s",
         coordinator.data,
     )
 
     if coordinator.data:
         for idx, ent in enumerate(coordinator.data):
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "In sensor.py::async_setup_platform: post-async_config_entry_first_refresh: idx %s, ent %s, val %s",
                 idx,
                 ent,
@@ -150,7 +150,7 @@ class OSBeeRSSISensor(CoordinatorEntity, SensorEntity):
 
     def __init__(self, coordinator, idx, key):
         """Pass coordinator to CoordinatorEntity."""
-        _LOGGER.warning(
+        _LOGGER.debug(
             "In __init__::OSBeeRSSISensor::__init__: idx = %s, key = %s", idx, key
         )
         super().__init__(coordinator, context=idx)
@@ -162,7 +162,7 @@ class OSBeeRSSISensor(CoordinatorEntity, SensorEntity):
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""
-        _LOGGER.warning(
+        _LOGGER.debug(
             "In __init__::OSBeeRSSISensor::_handle_coordinator_update, data = %s",
             self.coordinator.data,
         )
@@ -172,5 +172,5 @@ class OSBeeRSSISensor(CoordinatorEntity, SensorEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
-        _LOGGER.warning("In __init__::OSBeeRSSISensor::unique_id")
+        _LOGGER.debug("In __init__::OSBeeRSSISensor::unique_id")
         return f"""{self._mac.replace(":", "")}_{self._key}"""

--- a/custom_components/osbee/switch.py
+++ b/custom_components/osbee/switch.py
@@ -32,7 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 def setup(hass: HomeAssistant, config: ConfigType) -> bool:
     """Your controller/hub specific code."""
 
-    _LOGGER.warning("In switch.py::setup")
+    _LOGGER.debug("In switch.py::setup")
 
     return True
 
@@ -91,7 +91,7 @@ async def async_setup_platform(
     which risks skew and incompatibility (WET not DRY) so will eventually need to be reconciled.
     """
 
-    _LOGGER.warning("In switch.py::async_setup_platform: config is %s", config)
+    _LOGGER.debug("In switch.py::async_setup_platform: config is %s", config)
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {"coordinators": {}, "hubs": {}}
     if config[CONF_HOST] not in hass.data[DOMAIN]["hubs"]:
@@ -113,7 +113,7 @@ async def async_setup_platform(
     # coordinator.async_refresh() instead
     #
 
-    _LOGGER.warning(
+    _LOGGER.debug(
         "In switch.py::async_setup_platform: post-async_config_entry_first_refresh: data is %s",
         coordinator.data,
     )
@@ -143,7 +143,7 @@ class OSBeeZoneSwitch(CoordinatorEntity, SwitchEntity):
 
     def __init__(self, coordinator, zone_id, zone_name, hub):
         """Pass coordinator to CoordinatorEntity."""
-        _LOGGER.warning(
+        _LOGGER.debug(
             "__init__::OSBeeZoneSensor::__init__: zone_id = %s",
             zone_id,
         )
@@ -156,7 +156,7 @@ class OSBeeZoneSwitch(CoordinatorEntity, SwitchEntity):
     @property
     def unique_id(self) -> str:
         """Return a unique, Home Assistant friendly identifier for this entity."""
-        _LOGGER.warning("__init__::OSBeeZoneSensor::unique_id")
+        _LOGGER.debug("__init__::OSBeeZoneSensor::unique_id")
         return f"""{self._mac.replace(":", "")}_zone_{self._zone_id}"""
 
     async def async_turn_off(self, **kwargs: Any) -> None:

--- a/custom_components/osbee/switch.py
+++ b/custom_components/osbee/switch.py
@@ -10,7 +10,7 @@ from homeassistant.components.switch import (
     PLATFORM_SCHEMA,
     SwitchEntity,
 )
-from homeassistant.const import CONF_HOST
+from homeassistant.const import CONF_HOST, CONF_TIMEOUT
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -40,6 +40,7 @@ def setup(hass: HomeAssistant, config: ConfigType) -> bool:
 PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
+        vol.Optional(CONF_TIMEOUT, default=1800): cv.positive_int,
         # vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
@@ -49,7 +50,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 #
 # hass.data[DOMAIN]: {
 #     "192.168.1.77": {
-#         "h": an OSBeeAPI ("192.168.1.77", <async_client session>)
+#         "h": an OSBeeAPI ("192.168.1.77", 900, <async_client session>)
 #         "c": an OSBeeHubCoordinator (hass, ^^ that OSBeeAPI)
 #     }, ...
 # }
@@ -95,7 +96,11 @@ async def async_setup_platform(
     if DOMAIN not in hass.data:
         hass.data[DOMAIN] = {"coordinators": {}, "hubs": {}}
     if config[CONF_HOST] not in hass.data[DOMAIN]["hubs"]:
-        h = OSBeeAPI(config[CONF_HOST], async_create_clientsession(hass))
+        h = OSBeeAPI(
+            config[CONF_HOST],
+            config[CONF_TIMEOUT] if CONF_TIMEOUT in config else 900,
+            async_create_clientsession(hass),
+        )
         c = OSBeeHubCoordinator(hass, h)
 
         hass.data[DOMAIN]["hubs"].update({config[CONF_HOST]: {"h": h, "c": c}})


### PR DESCRIPTION
Allow user-settable maximum runtime (rather than default 30 min).

For expediency, the max runtime of the OSBee was set to 30 minutes: valves would be activated with adhoc "programs" to run for 30 minutes.  These programs would be stopped when the valves were turned off (via switch proxy objects in Hass).

The net effect was that if a switch was turned on and expected to run more than 30 minutes, it would silently turn itself off.

This change allows the user to configure a longer maximum runtime by configuring a "timeout: NN" value, in seconds:
```
binary_sensor:
  - platform: osbee
    host: 192.168.1.20
    timeout: 2700
sensor:
  - platform: osbee
    host: 192.168.1.20
    timeout: 2700
switch:
  - platform: osbee
    host: 192.168.1.20
    timeout: 2700
```
This OSBee can now support running an irrigation valve for up to 45 minutes before OSBee will automatically close the valve at the end of the "program".

Nope, the config is still duplicate.  :(