### PR TITLE
Feature: Configurable token

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,32 +63,39 @@ banned, this is what works so very well.
 ### Configuring the Current Code
 
 Right now, this current release, you will need to make redundant platform configs per-entity.  For
-example, assuming you have two OSBees (on 192.168.1.44 and 192.168.1.45):
+example, assuming you have two OSBees (on 192.168.1.44 and 192.168.1.45), and 1.44 can run for a
+maximum of 45 minutes (2700 seconds), but 1.45 keeps the default 15-minute window.  Tokens for 1.44
+and 1.45 are "BobIsAGiant" and "AllanIsTheKing", respectively.
 
 ```yaml
 
 binary_sensor:
   - platform: osbee
     host: 192.168.1.44
+    timeout: 2700
+    token: BobIsAGiant
   - platform: osbee
     host: 192.168.1.45
+    token: AllanIsTheKing
 
 sensor:
   - platform: osbee
     host: 192.168.1.44
+    timeout: 2700
+    token: BobIsAGiant
   - platform: osbee
     host: 192.168.1.45
+    token: AllanIsTheKing
 
 switch:
   - platform: osbee
     host: 192.168.1.44
+    timeout: 2700
+    token: BobIsAGiant
   - platform: osbee
     host: 192.168.1.45
+    token: AllanIsTheKing
 ```
-
-Currently, in THIS release, the token is set to the default.  If you want configurability sooner,
-please file an issue in this GitHub Project.  Yes, it tells me what's important, and tells me "hey,
-someone uses this, it's a useful thing".
 
 
 ### What about Config Flow?

--- a/custom_components/osbee/binary_sensor.py
+++ b/custom_components/osbee/binary_sensor.py
@@ -9,7 +9,7 @@ from homeassistant.components.binary_sensor import (
     PLATFORM_SCHEMA,
     BinarySensorEntity,
 )
-from homeassistant.const import CONF_HOST, CONF_TIMEOUT
+from homeassistant.const import CONF_HOST, CONF_TIMEOUT, CONF_TOKEN
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -40,6 +40,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_TIMEOUT, default=1800): cv.positive_int,
+        vol.Optional(
+            CONF_TOKEN, default="opendoor"
+        ): cv.string,  # "opendoor" is default in docs
         # vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
@@ -49,7 +52,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 #
 # hass.data[DOMAIN]: {
 #     "192.168.1.77": {
-#         "h": an OSBeeAPI ("192.168.1.77", 900, <async_client session>)
+#         "h": an OSBeeAPI ("192.168.1.77", 900, "opendoor", <async_client session>)
 #         "c": an OSBeeHubCoordinator (hass, ^^ that OSBeeAPI)
 #     }, ...
 # }
@@ -99,6 +102,7 @@ async def async_setup_platform(
         h = OSBeeAPI(
             config[CONF_HOST],
             config[CONF_TIMEOUT] if CONF_TIMEOUT in config else 900,
+            config[CONF_TOKEN] if CONF_TOKEN in config else "opendoor",
             async_create_clientsession(hass),
         )
         c = OSBeeHubCoordinator(hass, h)

--- a/custom_components/osbee/osbeeapi.py
+++ b/custom_components/osbee/osbeeapi.py
@@ -16,7 +16,9 @@ _LOGGER = logging.getLogger(__name__)
 class OSBeeAPI:
     """aiohttp facade for API requests to OSB Hub device."""
 
-    def __init__(self, host, max_runtime: int, session: aiohttp.ClientSession) -> None:
+    def __init__(
+        self, host: str, max_runtime: int, token: str, session: aiohttp.ClientSession
+    ) -> None:
         """Create an OSBeeAPI by offering a host, and an async session to get there."""
         self._host = host
         self._jc_cache = None
@@ -24,6 +26,7 @@ class OSBeeAPI:
         self._max_runtime = max_runtime
         self._session = session
         self.lock = Lock()
+        self._token = token
         _LOGGER.warning(
             "created OSBeeAPI at %s max_runtime %s (%s)",
             self._host,
@@ -109,10 +112,10 @@ class OSBeeAPI:
         #  - Example: pid=77&zbits=3&dur=300 turns on zones 1 and 2 manually for 5 minutes
 
         if self._jc_cache["zbits"] == 0:  # on zbits==0, we need to actually reset
-            url = f"http://{self._host}/cc?dkey=opendoor&reset=1"
+            url = f"http://{self._host}/cc?dkey={self._token}&reset=1"
         else:
             new_bitz = self._jc_cache["zbits"]  # avoid triple-quoting
-            url = f"http://{self._host}/rp?dkey=opendoor&pid=77&zbits={new_bitz}&dur={self._max_runtime}"
+            url = f"http://{self._host}/rp?dkey={self._token}&pid=77&zbits={new_bitz}&dur={self._max_runtime}"
 
         async with self._session.get(url) as rp_request:
             if rp_request.status == 401:

--- a/custom_components/osbee/sensor.py
+++ b/custom_components/osbee/sensor.py
@@ -13,6 +13,7 @@ from homeassistant.components.sensor import (
 from homeassistant.const import (
     CONF_HOST,
     CONF_TIMEOUT,
+    CONF_TOKEN,
     SIGNAL_STRENGTH_DECIBELS,
 )
 from homeassistant.core import HomeAssistant, callback
@@ -43,6 +44,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_TIMEOUT, default=1800): cv.positive_int,
+        vol.Optional(
+            CONF_TOKEN, default="opendoor"
+        ): cv.string,  # "opendoor" is default in docs
         # vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
@@ -52,7 +56,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 #
 # hass.data[DOMAIN]: {
 #     "192.168.1.77": {
-#         "h": an OSBeeAPI ("192.168.1.77", 900, <async_client session>)
+#         "h": an OSBeeAPI ("192.168.1.77", 900, "opendoor", <async_client session>)
 #         "c": an OSBeeHubCoordinator (hass, ^^ that OSBeeAPI)
 #     }, ...
 # }
@@ -97,6 +101,7 @@ async def async_setup_platform(
         h = OSBeeAPI(
             config[CONF_HOST],
             config[CONF_TIMEOUT] if CONF_TIMEOUT in config else 900,
+            config[CONF_TOKEN] if CONF_TOKEN in config else "opendoor",
             async_create_clientsession(hass),
         )
         c = OSBeeHubCoordinator(hass, h)

--- a/custom_components/osbee/switch.py
+++ b/custom_components/osbee/switch.py
@@ -10,7 +10,7 @@ from homeassistant.components.switch import (
     PLATFORM_SCHEMA,
     SwitchEntity,
 )
-from homeassistant.const import CONF_HOST, CONF_TIMEOUT
+from homeassistant.const import CONF_HOST, CONF_TIMEOUT, CONF_TOKEN
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_create_clientsession
 import homeassistant.helpers.config_validation as cv
@@ -41,6 +41,9 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
     {
         vol.Required(CONF_HOST): cv.string,
         vol.Optional(CONF_TIMEOUT, default=1800): cv.positive_int,
+        vol.Optional(
+            CONF_TOKEN, default="opendoor"
+        ): cv.string,  # "opendoor" is default in docs
         # vol.Optional(CONF_NAME, default=DEFAULT_NAME): cv.string,
     }
 )
@@ -50,7 +53,7 @@ PLATFORM_SCHEMA = PLATFORM_SCHEMA.extend(
 #
 # hass.data[DOMAIN]: {
 #     "192.168.1.77": {
-#         "h": an OSBeeAPI ("192.168.1.77", 900, <async_client session>)
+#         "h": an OSBeeAPI ("192.168.1.77", 900, "opendoor", <async_client session>)
 #         "c": an OSBeeHubCoordinator (hass, ^^ that OSBeeAPI)
 #     }, ...
 # }
@@ -99,6 +102,7 @@ async def async_setup_platform(
         h = OSBeeAPI(
             config[CONF_HOST],
             config[CONF_TIMEOUT] if CONF_TIMEOUT in config else 900,
+            config[CONF_TOKEN] if CONF_TOKEN in config else "opendoor",
             async_create_clientsession(hass),
         )
         c = OSBeeHubCoordinator(hass, h)


### PR DESCRIPTION
Permit the configuration of a non-default token to talk to the OSBee

The default token for the OSBee was hard-coded for expediency; this PR allows a different value to be set:
```yaml
binary_sensor:
  - platform: osbee
    host: 192.168.1.22
    token: BobIsAGiant

sensor:
  - platform: osbee
    host: 192.168.1.22
    token: BobIsAGiant

switch:
  - platform: osbee
    host: 192.168.1.22
    token: BobIsAGiant
```

Configuration is still redundant: the first block that is recognized and creates the OSBeeAPI proxy object is the token that gets used.  Note that multi-threaded setup can give inconsistent results if different tokens are currently given for switch/sensor/binary_sensor.
