### PR TITLE
fix: add dependency to integration

### DIFF
--- a/custom_components/osbee/manifest.json
+++ b/custom_components/osbee/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/chickenandpork/hass-osbee/issues",
-  "requirements": [],
+  "requirements": [ "osbee" ],
   "ssdp": [],
   "version": "0.0.2",
   "zeroconf": []


### PR DESCRIPTION
Meh.  Minor thing.  Let's add a manifest so that if we do pump this up to HACS, it's mostly defined already.