### PR TITLE
fix: get release version stamped into manifest for HACS

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,8 @@ jobs:
         # - enable "Allow Github Actions to create and approve pull requests"
         id: release
         with:
-          release-type: simple
+          release-type: generic
+          jsonpath: "custom_components/osbee/manifest.json"
       - name: Clone Repo
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v4


### PR DESCRIPTION
It would be great if the released version gets stamped into the `manifest.json` so that HA and HACS can assume the same version as the one actually released.  inorite?  crazy.