### PR TITLE
fix: fix the poorly-stripped import migration

### DIFF
--- a/custom_components/osbee/binary_sensor.py
+++ b/custom_components/osbee/binary_sensor.py
@@ -18,10 +18,10 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
+from osbee import OSBeeAPI
 
 from .const import DOMAIN
 from .coordinator import OSBeeHubCoordinator
-from .osbeeapi import OSBeeAPI
 
 DEFAULT_NAME = "OSBee - Binary Sensor"
 

--- a/custom_components/osbee/manifest.json
+++ b/custom_components/osbee/manifest.json
@@ -8,7 +8,7 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/chickenandpork/hass-osbee/issues",
-  "requirements": [ "osbee" ],
+  "requirements": [ "osbee>0.2.0" ],
   "ssdp": [],
   "version": "0.0.2",
   "zeroconf": []

--- a/custom_components/osbee/sensor.py
+++ b/custom_components/osbee/sensor.py
@@ -22,10 +22,10 @@ from homeassistant.helpers.aiohttp_client import async_create_clientsession
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
+from osbee import OSBeeAPI
 
 from .const import DOMAIN
 from .coordinator import OSBeeHubCoordinator
-from .osbeeapi import OSBeeAPI
 
 DEFAULT_NAME = "OSBee - Sensor"
 

--- a/custom_components/osbee/switch.py
+++ b/custom_components/osbee/switch.py
@@ -19,10 +19,10 @@ from homeassistant.helpers.typing import ConfigType, DiscoveryInfoType
 from homeassistant.helpers.update_coordinator import (
     CoordinatorEntity,
 )
+from osbee import OSBeeAPI
 
 from .const import DOMAIN
 from .coordinator import OSBeeHubCoordinator
-from .osbeeapi import OSBeeAPI
 
 DEFAULT_NAME = "OSBee - Valve Switch"
 


### PR DESCRIPTION
#19 tried to strip out the imports, but that didn't quite do the job.  Some imports were improperly based on the old combined setup, and hey, it still worked on my side.

I need to do some sort of mocking and checking on this; that's embarrassing

Meanwhile, the lib is cleaned in `osbee` in pypi, and this commit should clean up the exceptions being thrown at restart.
