### PR TITLE
fix: different URL for google-github-actions/release-please-action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -28,7 +28,7 @@ jobs:
       pull-requests: write
     needs: [build]
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         # Settings -> Actions -> General -> Workflow Permissions
         # - select "Read repo contents", and
         # - enable "Allow Github Actions to create and approve pull requests"


### PR DESCRIPTION
in `https://github.com/google-github-actions/release-please-action/pull/1` the old action group/owner changes