### PR TITLE
fix: revert releaser to allow simple releaser to run

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,8 +34,7 @@ jobs:
         # - enable "Allow Github Actions to create and approve pull requests"
         id: release
         with:
-          release-type: generic
-          jsonpath: "custom_components/osbee/manifest.json"
+          release-type: simple
       - name: Clone Repo
         if: ${{ steps.release.outputs.release_created }}
         uses: actions/checkout@v4


### PR DESCRIPTION
After some attempts to get the release strategies and such working in release-please, I need to just revert the experiments to get a release functional.