### PR TITLE
fix: Incorporate osbee-0.3.1 fixing unable to install osbee==0.3.0

### DIFF
--- a/custom_components/osbee/manifest.json
+++ b/custom_components/osbee/manifest.json
@@ -8,8 +8,8 @@
   "homekit": {},
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/chickenandpork/hass-osbee/issues",
-  "requirements": [ "osbee>0.2.0" ],
+  "requirements": [ "osbee>0.3.0" ],
   "ssdp": [],
-  "version": "0.0.2",
+  "version": "0.0.3",
   "zeroconf": []
 }


### PR DESCRIPTION
- fix: `Unable to install package osbee>0.2.0`

osbee-0.3.1 drops a dependency that is technically needed (`typing`) but that HomeAssistant blocks its constraints file.

Should allow us to install on HomeAssistant again, but cannot test before production release.